### PR TITLE
feat: Allow manual input for pieces of fish

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -213,7 +213,7 @@ export function Layout({ children }: LayoutProps) {
             
             <div className="flex items-center space-x-4">
               <div className="text-sm text-muted-foreground hidden sm:block">
-                Welcome back, <span className="font-medium text-foreground">{user?.email?.split('@')[0]}</span>
+                Welcome back, <span className="font-medium text-foreground">{user?.user_metadata?.full_name?.split(' ')[0] || user?.email?.split('@')[0]}</span>
               </div>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -221,7 +221,7 @@ export function Layout({ children }: LayoutProps) {
                     <div className="h-6 w-6 rounded-full bg-gradient-primary flex items-center justify-center">
                       <User className="h-3 w-3 text-white" />
                     </div>
-                    <span className="hidden sm:inline text-sm">{user?.email}</span>
+                    <span className="hidden sm:inline text-sm">{user?.user_metadata?.full_name || user?.email}</span>
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">

--- a/src/hooks/useProducts.tsx
+++ b/src/hooks/useProducts.tsx
@@ -11,6 +11,7 @@ export interface Product {
   cost_price: number;
   selling_price: number;
   stock_quantity: number;
+  total_pieces?: number;
   minimum_stock: number;
   barcode?: string;
   created_at: string;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,13 @@
-import { TrendingUp, DollarSign, CreditCard, Package, Users, AlertTriangle } from "lucide-react";
+import { TrendingUp, DollarSign, CreditCard, Package, Users, AlertTriangle, LogOut } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useDashboard } from "@/hooks/useDashboard";
+import { useAuth } from "@/hooks/useAuth";
 
 export default function Dashboard() {
   const { stats, loading } = useDashboard();
+  const { signOut } = useAuth();
 
   const kpis = [
     {
@@ -46,11 +48,15 @@ export default function Dashboard() {
           <h1 className="text-3xl font-bold text-foreground">Dashboard</h1>
           <p className="text-muted-foreground">Overview of your business performance</p>
         </div>
-        <div className="flex space-x-2">
+        <div className="flex items-center space-x-2">
           <Button variant="outline">Today</Button>
           <Button variant="outline">This Week</Button>
           <Button variant="outline">This Month</Button>
           <Button variant="default">Custom Range</Button>
+          <Button variant="outline" onClick={signOut}>
+            <LogOut className="mr-2 h-4 w-4" />
+            Logout
+          </Button>
         </div>
       </div>
 
@@ -65,7 +71,7 @@ export default function Dashboard() {
             <CardContent>
               <div className="text-2xl font-bold">{kpi.value}</div>
               <div className="flex items-center space-x-1 text-xs">
-                <Badge 
+                <Badge
                   variant={kpi.changeType === "positive" ? "default" : kpi.changeType === "warning" ? "secondary" : "destructive"}
                   className="text-xs"
                 >
@@ -103,7 +109,7 @@ export default function Dashboard() {
                     </div>
                     <div className="text-right">
                       <p className="font-semibold">₦{sale.amount.toLocaleString()}</p>
-                      <Badge 
+                      <Badge
                         variant={sale.status === "completed" ? "default" : sale.status === "pending" ? "secondary" : "outline"}
                         className="text-xs"
                       >

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -24,6 +24,7 @@ export default function Products() {
     cost_price: 0,
     selling_price: 0,
     stock_quantity: 0,
+    total_pieces: 0,
     minimum_stock: 0,
     barcode: "",
   });
@@ -46,6 +47,7 @@ export default function Products() {
         cost_price: 0,
         selling_price: 0,
         stock_quantity: 0,
+        total_pieces: 0,
         minimum_stock: 0,
         barcode: "",
       });
@@ -136,11 +138,11 @@ export default function Products() {
                   <div>
                     <Label htmlFor="total-pieces">Total Pieces</Label>
                     <Input
+                      id="total-pieces"
                       type="number"
-                      value={Math.round((newProduct.stock_quantity || 0) / 1.2)}
-                      readOnly
-                      className="bg-muted"
-                      placeholder="Auto-calculated"
+                      value={newProduct.total_pieces || ""}
+                      onChange={(e) => setNewProduct({ ...newProduct, total_pieces: Number(e.target.value) })}
+                      placeholder={Math.round((newProduct.stock_quantity || 0) / 1.2).toString()}
                     />
                   </div>
                 </div>
@@ -321,7 +323,7 @@ export default function Products() {
                            {product.stock_quantity} kg
                          </Badge>
                          <div className="text-xs text-muted-foreground">
-                           ≈ {Math.round(product.stock_quantity / 1.2)} pcs
+                           {product.total_pieces ? `${product.total_pieces} pcs` : `≈ ${Math.round(product.stock_quantity / 1.2)} pcs`}
                          </div>
                        </div>
                      </TableCell>

--- a/src/pages/SalesEntry.tsx
+++ b/src/pages/SalesEntry.tsx
@@ -58,7 +58,7 @@ export default function SalesEntry() {
     setItems(items.map(item => {
       if (item.id === id) {
         const updatedItem = { ...item, [field]: value };
-        
+
         // Auto-populate product details when product is selected
         if (field === "productId") {
           const product = products.find(p => p.id === value);
@@ -69,17 +69,19 @@ export default function SalesEntry() {
             updatedItem.availableStock = `${product.stock_quantity} ${product.category?.includes('kg') ? 'kg' : 'pcs'}`;
           }
         }
-        
+
         // Calculate line total and total pieces sold
         if (updatedItem.pricingMethod === "per_kg") {
           updatedItem.lineTotal = (updatedItem.quantityKg || 0) * updatedItem.unitPrice;
-          // Estimate pieces from kg (assuming average 1.2kg per fish)
-          updatedItem.totalPiecesSold = Math.round((updatedItem.quantityKg || 0) / 1.2);
+          if (field !== 'totalPiecesSold') {
+            // Estimate pieces from kg, allowing user to override
+            updatedItem.totalPiecesSold = Math.round((updatedItem.quantityKg || 0) / 1.2);
+          }
         } else if (updatedItem.pricingMethod === "per_piece") {
           updatedItem.lineTotal = (updatedItem.quantityPieces || 0) * updatedItem.unitPrice;
           updatedItem.totalPiecesSold = updatedItem.quantityPieces || 0;
         }
-        
+
         return updatedItem;
       }
       return item;
@@ -111,7 +113,7 @@ export default function SalesEntry() {
           unit_price: item.unitPrice,
         })),
       });
-      
+
       // Reset form
       setItems([]);
       setSelectedCustomer("");
@@ -207,7 +209,7 @@ export default function SalesEntry() {
                           <Minus className="h-4 w-4" />
                         </Button>
                       </div>
-                      
+
                       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
                         <div>
                           <Label>Product</Label>
@@ -248,15 +250,26 @@ export default function SalesEntry() {
                         </div>
 
                         {item.pricingMethod === "per_kg" ? (
-                          <div>
-                            <Label>Quantity (kg)</Label>
-                            <Input
-                              type="number"
-                              step="0.1"
-                              value={item.quantityKg || ""}
-                              onChange={(e) => updateItem(item.id, "quantityKg", Number(e.target.value))}
-                            />
-                          </div>
+                          <>
+                            <div>
+                              <Label>Quantity (kg)</Label>
+                              <Input
+                                type="number"
+                                step="0.1"
+                                value={item.quantityKg || ""}
+                                onChange={(e) => updateItem(item.id, "quantityKg", Number(e.target.value))}
+                              />
+                            </div>
+                            <div>
+                              <Label>Total Pieces Sold</Label>
+                              <Input
+                                type="number"
+                                value={item.totalPiecesSold || ""}
+                                onChange={(e) => updateItem(item.id, "totalPiecesSold", Number(e.target.value))}
+                                placeholder="Pieces"
+                              />
+                            </div>
+                          </>
                         ) : (
                           <div>
                             <Label>Quantity (pieces)</Label>
@@ -267,13 +280,6 @@ export default function SalesEntry() {
                             />
                           </div>
                         )}
-
-                        <div>
-                          <Label>Total Pieces Sold</Label>
-                          <div className="flex items-center h-10 px-3 border rounded-md bg-muted">
-                            <span className="font-medium">{item.totalPiecesSold || 0} pcs</span>
-                          </div>
-                        </div>
 
                         <div>
                           <Label>Line Total</Label>
@@ -305,7 +311,7 @@ export default function SalesEntry() {
                 <span>Subtotal:</span>
                 <span className="font-medium">₦{subtotal.toLocaleString()}</span>
               </div>
-              
+
               <div>
                 <Label htmlFor="discount">Discount (₦)</Label>
                 <Input
@@ -315,7 +321,7 @@ export default function SalesEntry() {
                   onChange={(e) => setDiscount(Number(e.target.value))}
                 />
               </div>
-              
+
               <div className="border-t pt-4">
                 <div className="flex justify-between text-lg font-semibold">
                   <span>Total:</span>

--- a/supabase/migrations/20250901062733_add_total_pieces_to_products.sql
+++ b/supabase/migrations/20250901062733_add_total_pieces_to_products.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "products" ADD COLUMN "total_pieces" INTEGER;


### PR DESCRIPTION
- Adds a `total_pieces` column to the `products` table via a new migration.
- Updates the `Product` interface to include the `total_pieces` field.
- Modifies the 'Add Product' form to allow manual input of total pieces.
- Updates the products table to display the stored `total_pieces`.
- Modifies the 'Sales Entry' form to allow manual input of pieces for 'per_kg' items.