### PR TITLE
fix(build): correct import path for usePayments hook

### DIFF
--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/hooks/use-toast";
-import { usePayments } from "@/hooks/usePayments";
+import { usePayments } from "@/hooks/usePayment";
 import { useCustomers } from "@/hooks/useCustomers";
 
 


### PR DESCRIPTION
The build was failing because `src/pages/Payments.tsx` was trying to import the `usePayments` hook from `src/hooks/usePayments`, but the file is named `src/hooks/usePayment.tsx` (singular).

This commit corrects the import path to point to the correct file, resolving the build failure.