### PR TITLE
fix(db): Add user_id RLS policies to fix dashboard

### DIFF
--- a/supabase/migrations/20250905171300_add_user_id_rls_policies.sql
+++ b/supabase/migrations/20250905171300_add_user_id_rls_policies.sql
@@ -1,0 +1,45 @@
+-- Re-introduce user_id-based RLS policies for multi-tenancy compatibility
+-- This allows the frontend to continue using user_id for queries while
+-- the business_id logic can coexist for other purposes.
+
+-- Policies for tables used in the dashboard
+CREATE POLICY "Users can manage their own sales" ON public.sales FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can manage sale items for their sales" ON public.sale_items FOR ALL
+USING (EXISTS (SELECT 1 FROM public.sales WHERE public.sales.id = public.sale_items.sale_id AND public.sales.user_id = auth.uid()))
+WITH CHECK (EXISTS (SELECT 1 FROM public.sales WHERE public.sales.id = public.sale_items.sale_id AND public.sales.user_id = auth.uid()));
+
+CREATE POLICY "Users can manage their own inventory" ON public.inventory FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can manage their own customers" ON public.customers FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+-- Policies for other tables to ensure consistency
+CREATE POLICY "Users can manage their own products" ON public.products FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can manage their own purchases" ON public.purchases FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can manage purchase items for their purchases" ON public.purchase_items FOR ALL
+USING (EXISTS (SELECT 1 FROM public.purchases WHERE public.purchases.id = public.purchase_items.purchase_id AND public.purchases.user_id = auth.uid()))
+WITH CHECK (EXISTS (SELECT 1 FROM public.purchases WHERE public.purchases.id = public.purchase_items.purchase_id AND public.purchases.user_id = auth.uid()));
+
+CREATE POLICY "Users can manage their own payments" ON public.payments FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can manage their own expenses" ON public.expenses FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can manage their own stock updates" ON public.stock_updates FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
The dashboard was not loading any data because of a mismatch between the frontend queries and the backend's Row Level Security (RLS) policies.

A previous migration switched the multi-tenancy model to be based on `business_id`, but the frontend continued to query for data using `user_id`. This caused the RLS policies to block the queries, resulting in an empty dashboard.

This change introduces a new migration that adds RLS policies based on `user_id` for all relevant tables. This allows the existing frontend queries to succeed and correctly load data on the dashboard. The `business_id` policies are left in place to support other parts of the application.